### PR TITLE
Update Agora submodule to use the latest Well Known Keypairs

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -23,6 +23,8 @@
         "submodules/agora/source/agora/consensus/data/Transaction.d",
         "submodules/agora/source/agora/consensus/data/UTXO.d",
         "submodules/agora/source/agora/consensus/data/PreImageInfo.d",
+        "submodules/agora/source/agora/consensus/state/UTXOCache.d",
+        "submodules/agora/source/agora/consensus/state/UTXODB.d",
         "submodules/agora/source/agora/consensus/state/UTXOSet.d",
         "submodules/agora/source/agora/crypto/Crc16.d",
         "submodules/agora/source/agora/crypto/Key.d",


### PR DESCRIPTION
The GenesisBlock and the Wellknownkeys will change so we need Faucet to also use the correct agora submodule version.
Last commit will need to be updated to use v0.x.x agora with changes after https://github.com/bosagora/agora/pull/1778 is merged.

