### PR TITLE
Fix catchup when there are more than 20 blocks

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -106,6 +106,7 @@ private struct State
                 const long delta = (cast(long) this.utxos.storage.length) - current_len;
                 logInfo("UTXO delta: %s", delta);
                 this.known = blocks[$ - 1].header.height;
+                from += blocks.length;
             } while (this.known < height);
 
             assert(this.getOwnedUTXOs().length);


### PR DESCRIPTION
The previous commit didn't increment the right value,
leading to the same 20 blocks being endlessly fetched.