### PR TITLE
Use correct amount in `sendTransaction`

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -325,7 +325,7 @@ public class Faucet : FaucetAPI
     public override void sendTransaction (string recv, ulong amount)
     {
         PublicKey pubkey = PublicKey.fromString(recv);
-        Amount leftover = Amount(amount);
+        Amount leftover = amount.coins;
         auto owned_utxo_rng = this.state.owned_utxos.byKeyValue()
             // do not pick already used UTXOs
             .filter!(pair => pair.key !in this.used_utxos);
@@ -340,7 +340,7 @@ public class Faucet : FaucetAPI
         if (leftover <= first_utxo.value.output.value)
         {
             Transaction tx = txb.draw(leftover, [pubkey]).sign();
-            logInfo("Sending %s BOA to %s", amount, recv);
+            logInfo("Sending %s BOA to %s", amount.coins, recv);
             this.client.putTransaction(tx);
         }
         else
@@ -368,7 +368,7 @@ public class Faucet : FaucetAPI
             }
 
             Transaction tx = txb.sign();
-            logInfo("Sending %s BOA to %s", amount, recv);
+            logInfo("Sending %s BOA to %s", amount.coins, recv);
             this.client.putTransaction(tx);
         }
     }


### PR DESCRIPTION
The actual `Amount` that is sent is 10,000,000 times the original amount.
This amount includes the number of "cents".

This is similar to [`AmountFmt` in `PrettyPrinter`](https://github.com/bosagora/agora/blob/68df58ee57851017ccbd73da1b4c98000088a672/source/agora/utils/PrettyPrinter.d#L141-L170)