### PR TITLE
Do not wait until first block to keep sending txs

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -313,9 +313,6 @@ public class Faucet : FaucetAPI
         if (this.state.update(this.client, Height(this.state.known + 1)))
             logTrace("State has been updated: %s", this.state.known);
 
-        if (this.state.known < 1)
-            return logInfo("Waiting for setup to be completed");
-
         logInfo("About to send transactions...");
 
         // Sort them so we don't iterate multiple time


### PR DESCRIPTION
A recent PR removed the lockstep approach of Faucet,
where we would wait for a block to be generated until we sent new transactions.
However, the initialize 'setup' phase was kept. Since the setup has also be fixed
to be always performed (if not done yet) when the 'send' timer is called,
we can just remove this special case now.