### PR TITLE
Update Faucet to use `isPayment` in preparation for Agora update

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -117,7 +117,7 @@ private struct State
 
                 foreach (ref b; blocks)
                     foreach (ref tx; b.txs)
-                        if (tx.type == TxType.Payment)
+                        if (tx.isPayment)
                             this.utxos.updateUTXOCache(tx, b.header.height, PublicKey.init);
 
                 // Use signed arithmetic to avoid negative values wrapping around


### PR DESCRIPTION
Use `isPayment` for `tx`
    
Agora will soon be updated to specify the transaction type for each output.  
A new function `isPayment` will determine the transaction type.
This updates Faucet to use the new function.

Related to https://github.com/bosagora/agora/pull/2114