### PR TITLE
Fix `dub.json` to actually initialize the Vibe.d event loop (+ dockerignore)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Various build folder, modeled after Agora
+.dub/
+bin/
+submodules/*/.dub/
+submodules/*/*.a
+submodules/agora/source/scpp/build/
+submodules/vibe.d/*/.dub/
+submodules/vibe.d/*/*.a
+submodules/vibe.d/examples/
+submodules/vibe.d/tests/

--- a/dub.json
+++ b/dub.json
@@ -10,6 +10,8 @@
     "license": "MIT",
 
     "dflags": [ "-i", "-preview=in" ],
+    "lflags-linux": [ "--export-dynamic" ],
+    "lflags-osx": [ "-export_dynamic" ],
     "libs": [ "sqlite3", "sodium" ],
 
     "configurations": [

--- a/dub.json
+++ b/dub.json
@@ -3,6 +3,7 @@
     "description": "Your friendly transaction-happy bot",
 
     "targetPath": "bin/",
+    "targetType": "executable",
 
     "authors": [ "BPF Korea" ],
     "copyright": "Copyright © 2020-2021, BOSAGORA Foundation",
@@ -10,6 +11,26 @@
 
     "dflags": [ "-i", "-preview=in" ],
     "libs": [ "sqlite3", "sodium" ],
+
+    "configurations": [
+        {
+            "name": "epoll",
+            "platforms": [ "linux" ],
+            "versions": [ "EventcoreEpollDriver" ]
+        },
+        {
+            "name": "cfrunloop",
+            "platforms": [ "osx" ],
+            "versions": [ "EventcoreCFRunLoopDriver" ],
+            "lflags": [ "-framework", "CoreFoundation", "-framework", "CoreServices" ]
+        },
+        {
+            "name": "winapi",
+            "platforms": [ "windows" ],
+            "versions": [ "EventcoreWinAPIDriver" ]
+        }
+    ],
+
     "importPaths": [
         "source/",
 


### PR DESCRIPTION
So the integration test of Agora was failing because we were missing some of dub's magic.
Added it, and got the weirdest error, because the `faucet` binary which I had locally built was copied to the container verbatim. Added a dockerignore for that, then realized that the reason it was not overwritten was that adding `configuration` made `dub` infers the package as a library... And here we are. And while I was at it, added the export dynamic thing we have in Agora, because stacktraces are good.