### PR TITLE
Config max utxos and use config file

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -53,7 +53,6 @@
         "submodules/vibe-core/source/",
         "submodules/vibe.d/crypto/",
         "submodules/vibe.d/data/",
-        "submodules/vibe.d/db/",
         "submodules/vibe.d/http/",
         "submodules/vibe.d/inet/",
         "submodules/vibe.d/source/",

--- a/source/faucet/config.yaml
+++ b/source/faucet/config.yaml
@@ -2,6 +2,15 @@
 ##                                  Sample keys                               ##
 ################################################################################
 
+# How frequently we run our periodic task in seconds
+interval: 1
+
+# Between how many addresses we split a transaction by
+count: 1
+
+# Maximum number of utxo before merging instead of splitting
+max_utxos: 10
+
 # When we deploy Faucet on the real TestNet, the keys used will not be well-known.
 keys:
   - SAQXRDHTWME4GUIVNYCKPN433VJ4BJP2L2T7UWHGSSW47VFC67EQFY3S


### PR DESCRIPTION
1st commit just removes a compile time dub warning.
2nd commit makes the `interval` and `count` configurable from the config.yaml file. It also adds a new option for max utxos before merging rather than splitting.