### PR TITLE
Fix the behavior when using the config yaml

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,6 +10,7 @@
     "license": "MIT",
 
     "dflags": [ "-i", "-preview=in" ],
+    "dflags-ldc": [ "--link-defaultlib-debug" ],
     "lflags-linux": [ "--export-dynamic" ],
     "lflags-osx": [ "-export_dynamic" ],
     "libs": [ "sqlite3", "sodium" ],


### PR DESCRIPTION
Fix a few places where the `WK.Keys` were still used even though the config file was providing the keys to use.