### PR TITLE
A few small updates to help with solving the `tx rejected` issue

### DIFF
--- a/doc/config.local_single.yaml
+++ b/doc/config.local_single.yaml
@@ -17,10 +17,10 @@ tx_generator:
   send_interval: 1
 
   # Between how many addresses we split a transaction by
-  split_count: 1
+  split_count: 2
 
   # Maximum number of utxo before merging instead of splitting
-  merge_threshold: 5
+  merge_threshold: 50
 
   # Addresses to send transactions
   addresses:

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -297,7 +297,7 @@ public class Faucet : FaucetAPI
         if (utxo_len < 200)
         {
             assert(utxo_len >= 8);
-            this.splitTx(this.state.utxos.storage.byKeyValue(), 100)
+            this.splitTx(this.state.utxos.storage.byKeyValue(), count)
                 .take(8)
                 .each!(tx => this.randomClient().putTransaction(tx));
             this.faucet_stats.increaseMetricBy!"faucet_transactions_sent_total"(8);

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -268,7 +268,7 @@ public class Faucet : FaucetAPI
         // AA keys are addresses
         auto builder = TxBuilder(
             secret_keys.byKey().drop(uniform(0, secret_keys.length, rndGen)).front());
-        utxo_rng.each!(kv => builder.attach(kv.value.output, kv.key));
+        builder.attach(utxo_rng);
         return builder.sign(OutputType.Payment, 0, &this.keyUnlocker);
     }
 
@@ -347,7 +347,9 @@ public class Faucet : FaucetAPI
 
         if (this.state.utxos.storage.length > config.tx_generator.merge_threshold)
         {
-            auto tx = this.mergeTx(this.state.utxos.byKeyValue().take(uniform(10, 100, rndGen)));
+            auto tx = this.mergeTx(this.state.utxos.byKeyValue()
+                .map!(kv => tuple(kv.value.output, kv.key))
+                .take(uniform(10, 100, rndGen)));
             this.randomClient().putTransaction(tx);
             logDebug("Transaction sent: %s", tx);
             this.faucet_stats.increaseMetricBy!"faucet_transactions_sent_total"(1);


### PR DESCRIPTION
Currently when the Faucet merges `utxo` to create a `Transaction` with multiple `inputs` and a single `output` Agora rejects the tx with `Rejected tx. Reason: LockType.Key signature in unlock script failed validation.`
This current commits do not fix it but might help.