### PR TITLE
Web interface: Start it when configured via config file

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -497,19 +497,6 @@ int main (string[] args)
             .each!(kp => secret_keys.require(kp.address, kp.secret));
     logInfo("%s", config);
 
-    if (bind.length) try
-    {
-        auto bindurl = URL(bind);
-        string address = bindurl.host;
-        uint port = bindurl.port;
-    }
-    catch (Exception exc)
-    {
-        stderr.writeln("Could not parse '", bind, "' as a valid URL");
-        stderr.writeln("Make sure the address contains a scheme, e.g. 'http://127.0.0.1:2766'");
-        return 1;
-    }
-
     logInfo("We'll be sending transactions to the following clients: %s", config.tx_generator.addresses);
     inst = new Faucet();
     inst.stats_server = new StatsServer(config.tx_generator.stats_port);

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -504,7 +504,8 @@ int main (string[] args)
     setLogLevel(verbose ? LogLevel.trace : LogLevel.info);
 
     inst.sendTx = setTimer(config.tx_generator.send_interval.seconds, () => inst.send(), true);
-    inst.webInterface = bind.length ? startListeningInterface(config, inst) : HTTPListener.init;
+    if (config.web.address.length)
+        inst.webInterface = startListeningInterface(config, inst);
     return runEventLoop();
 }
 


### PR DESCRIPTION
```
Previously, the condition was only true when the user passed --bind=value
on the command line, but should also be true if something is configured
in the config file.
```