### PR TITLE
Remove `amount` parameter from `sendTransaction` endpoint

### DIFF
--- a/source/faucet/api.d
+++ b/source/faucet/api.d
@@ -27,7 +27,7 @@ import vibe.http.common;
 
     The faucet can:
     - Return an array of all UTXOs known
-    - Send `Amount` BOA to `KEY`, using owned UTXOs
+    - Send 100 BOA to `KEY`, using owned UTXOs
     - Make `Transaction`s
 
 *******************************************************************************/
@@ -53,17 +53,16 @@ public interface FaucetAPI
 
     /***************************************************************************
 
-        Send `amount` BOA to `KEY`, using owned UTXOs
+        Send 100 BOA to `KEY`, using owned UTXOs
 
         API:
           POST /send
 
         Params:
           recv = the destination key
-          amount = amount of BOA
 
     ***************************************************************************/
 
     @path("/send")
-    public void sendTransaction (@viaQuery("recv") string recv, @viaQuery("amount") ulong amount);
+    public void sendTransaction (@viaQuery("recv") string recv);
 }

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -374,9 +374,10 @@ public class Faucet : FaucetAPI
     }
 
     /// POST: /send_transaction
-    public override void sendTransaction (string recv, ulong amount)
+    public override void sendTransaction (string recv)
     {
         PublicKey pubkey = PublicKey.fromString(recv);
+        ulong amount = 100;
         Amount leftover = amount.coins;
         auto owned_utxo_rng = this.state.owned_utxos.byKeyValue()
             // do not pick already used UTXOs
@@ -393,7 +394,7 @@ public class Faucet : FaucetAPI
         {
             Transaction tx = txb.draw(leftover, [pubkey])
                 .sign(OutputType.Payment, 0, &this.keyUnlocker);
-            logInfo("Sending %s BOA to %s", amount.coins, recv);
+            logInfo("Sending %s BOA to %s", amount, recv);
             this.randomClient().putTransaction(tx);
             this.faucet_stats.increaseMetricBy!"faucet_transactions_sent_total"(1);
         }
@@ -423,7 +424,7 @@ public class Faucet : FaucetAPI
 
             Transaction tx = txb
                 .sign(OutputType.Payment, 0, &this.keyUnlocker);
-            logInfo("Sending %s BOA to %s", amount.coins, recv);
+            logInfo("Sending %s BOA to %s", amount, recv);
             this.randomClient().putTransaction(tx);
             this.faucet_stats.increaseMetricBy!"faucet_transactions_sent_total"(1);
         }


### PR DESCRIPTION
In the faucet frontend, the amount of coins sent is fixed.
There is no need for an `amount` parameter.

Fixes #105 