### PR TITLE
Frontend: Correct Docker image setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN AGORA_VERSION=${AGORA_VERSION} dub build --skip-registry=all --compiler=ldc2
 FROM alpine:edge
 WORKDIR /root/faucet/
 RUN apk add --no-cache ldc-runtime llvm-libunwind libgcc libsodium sqlite-libs
-COPY frontend/ /root/faucet/frontend/
+COPY frontend/ /usr/share/faucet/frontend/
 COPY --from=Builder /root/faucet/bin/faucet /usr/bin/faucet
 ENTRYPOINT [ "/usr/bin/faucet" ]

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -532,6 +532,9 @@ private string getStaticFilePath ()
     if (std.file.exists("frontend/index.html"))
         return std.file.getcwd() ~ "/frontend/";
 
+    if (std.file.exists("/usr/share/faucet/frontend/index.html"))
+        return "/usr/share/faucet/frontend/";
+
     throw new Exception("Files not found. " ~
                         "This might mean your faucet is not installed correctly. " ~
                         "Searched for `index.html` in '" ~ std.file.getcwd() ~


### PR DESCRIPTION
The `frontend` folder was not bound properly, so the `index.html` was unable to be found.
Therefore, we use `/usr/share/faucet/frontend/`.