### PR TITLE
Frontend: Send coins using jQuery and Ajax

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,6 +31,13 @@
             <br>
               <input id="submitform" class="w-90 btn btn-lg btn-primary" type="submit" value="Send test BOA to address">
         </form>
+      <br>
+        <div id="valid" class="result" style="display: none;">
+          <p>Test BOA successfully sent!</p>
+        </div>
+        <div id="invalid" class="result" style="display: none;">
+          <p>Invalid address!</p>
+        </div>
     </main>
   </body>
   <script>
@@ -46,6 +53,14 @@
           contentType : "application/json",
           type : "POST",
           data : result,
+          success : function(data)
+          {
+            $('#valid').fadeIn(250).fadeOut(5000);
+          },
+          error : function()
+          {
+            $('#invalid').fadeIn(250).fadeOut(5000);
+          },
         });
       });
     });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
 
     <link rel="icon" href="favicon.ico" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-wEmeIV1mKuiNpC+IOBjI7aAzPcEZeedi5yW5f2yOq55WWLwNGmvvx4Um1vskeMj0" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 
     <!-- Custom styles for this template  -->
     <link href="styles.css" rel="stylesheet">
@@ -19,8 +20,8 @@
         <form action="send" method="post">
           <h1 class="h3 mb-3 fw-normal">Welcome to the BOSAGORA Faucet</h1>
             <div class="form-floating">
-              <input name="recv" type="text" class="form-control" id="floatingInput">
-              <label for="floatingInput">Enter your address</label>
+              <input id="recv" type="text" class="form-control">
+              <label for="recv">Enter your address</label>
             </div>
             <br>
             <div class="form-floating">
@@ -28,8 +29,25 @@
               <label for="floatingInput">Amount (fixed at 100 BOA)</label>
             </div>
             <br>
-              <input class="w-90 btn btn-lg btn-primary" type="submit" value="Send test BOA to address">
+              <input id="submitform" class="w-90 btn btn-lg btn-primary" type="submit" value="Send test BOA to address">
         </form>
     </main>
   </body>
+  <script>
+    $(document).ready(function()
+    {
+      $("#submitform").click(function(e)
+      {
+        e.preventDefault(); // STOP default action
+        var result = JSON.stringify({recv : $("#recv").val()});
+        $.ajax(
+        {
+          url : "send",
+          contentType : "application/json",
+          type : "POST",
+          data : result,
+        });
+      });
+    });
+  </script>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -41,3 +41,19 @@ body {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
 }
+
+.result {
+  border-radius: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+#valid {
+  background: #d5f5e3;
+  color: #196f3d;
+}
+
+#invalid {
+  background: #ffccd9;
+  color: #ff3333;
+}

--- a/source/faucet/api.d
+++ b/source/faucet/api.d
@@ -64,5 +64,5 @@ public interface FaucetAPI
     ***************************************************************************/
 
     @path("/send")
-    public void sendTransaction (@viaQuery("recv") string recv);
+    public void sendTransaction (@viaBody("recv") string recv);
 }

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -373,7 +373,7 @@ public class Faucet : FaucetAPI
         return this.state.utxos.storage;
     }
 
-    /// POST: /send_transaction
+    /// POST: /send
     public override void sendTransaction (string recv)
     {
         PublicKey pubkey = PublicKey.fromString(recv);


### PR DESCRIPTION
 - If we use `jQuery` and `Ajax`, we can send coins using the correct `HTTP` method and `Content-Type`.
- The frontend now shows a validation message below the input field, depending on the given address.

1st commit pair-programmed w/ @ferencdg  
Fixes #106 