### PR TITLE
Issue116: display relevant errors in webpage when fails to send boa

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,7 +36,7 @@
           <p>Test BOA successfully sent!</p>
         </div>
         <div id="invalid" class="result" style="display: none;">
-          <p>Invalid address!</p>
+          <p>Error message</p>
         </div>
     </main>
   </body>
@@ -46,21 +46,27 @@
       $("#submitform").click(function(e)
       {
         e.preventDefault(); // STOP default action
-        var result = JSON.stringify({recv : $("#recv").val()});
+        $('#valid').fadeOut(10);
+        $('#invalid').fadeOut(10);
+        var address = JSON.stringify({recv : $("#recv").val()});
         $.ajax(
         {
           url : "send",
           contentType : "application/json",
           type : "POST",
-          data : result,
-          success : function(data)
-          {
-            $('#valid').fadeIn(250).fadeOut(5000);
-          },
-          error : function()
-          {
-            $('#invalid').fadeIn(250).fadeOut(5000);
-          },
+          data : address
+        }).done(function(data) {
+            $('#valid').fadeIn(250);
+        }).fail(function(data) {
+            var failReason;
+            try {
+                failReason = data['responseJSON']['statusMessage'];
+            }
+            catch (e) {
+                console.log(e);
+                failReason = "Faucet currently unavailable. Please try later.";
+            }
+            $('#invalid').text(failReason).fadeIn(250);
         });
       });
     });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,11 +41,16 @@
     </main>
   </body>
   <script>
-    $(document).ready(function()
-    {
-      $("#submitform").click(function(e)
-      {
+    $(document).ready(function() {
+        $('#submitform').prop('disabled', true);
+        $('#recv').keyup(function() {
+            if($(this).val() != '') {
+            $('#submitform').prop('disabled', false);
+            }
+        });
+      $("#submitform").click(function(e) {
         e.preventDefault(); // STOP default action
+        $('#submitform').prop('disabled', true);
         $('#valid').fadeOut(10);
         $('#invalid').fadeOut(10);
         var address = JSON.stringify({recv : $("#recv").val()});


### PR DESCRIPTION
Previously the error message shown on the web page on failure was hardcoded to `Invalid address`. 
Now the error message returned in the json response from the Faucet is used.