### PR TITLE
Prevent sending coins when there is less than one UTXO

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -382,6 +382,14 @@ public class Faucet : FaucetAPI
         auto owned_utxo_rng = this.state.owned_utxos.byKeyValue()
             // do not pick already used UTXOs
             .filter!(pair => pair.key !in this.used_utxos);
+
+        auto owned_utxo_len = owned_utxo_rng.take(2).count;
+        if (owned_utxo_len <= 1)
+        {
+            logError("Insufficient UTXOs in storage. # of UTXOs: %s", owned_utxo_len);
+            throw new Exception(format("Insufficient UTXOs in storage. # of UTXOs: %s", owned_utxo_len));
+        }
+
         auto first_utxo = owned_utxo_rng.front;
         // add used UTXO to to used_utxos
         this.used_utxos[first_utxo.key] = first_utxo.value;


### PR DESCRIPTION
Attempting to send coins without any `UTXO` or with one `UTXO` results in an assertion error.
The faucet now checks the number of `UTXO`s before sending and prevents sending if there is less than one.

Fixes #115 