### PR TITLE
Add fees to transactions

### DIFF
--- a/source/faucet/config.d
+++ b/source/faucet/config.d
@@ -30,6 +30,12 @@ public struct Config
     /// config for faucet web
     Web web;
 
+    /// lower threshold of the fee per byte
+    ulong min_fee_per_byte = 700;
+
+    /// upper threshold of the fee per byte
+    ulong max_fee_per_byte = 1000;
+
     this (TxGenerator tx_generator, Web web)
     {
         this.tx_generator = tx_generator;


### PR DESCRIPTION
To test the fee distribution on the live env, the transactions generated with the frontend include fees.
The fee equals fee per byte, which is a random value within the threshold, multiplied by the transaction size.

e.g. there can be a transaction with:
Input = 610,000,000,000,000
Output 1 (refund) =  609,998,999,866,365
Output 2 (BOA sent) = 1,000,000,000
Fee (implied) = 133,635

Fixes #26 