### PR TITLE
Fix calculation of average amount in `send` method

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -343,13 +343,7 @@ public class Faucet : FaucetAPI
 
         immutable median = sutxo[size / 2].output.value;
         // Should be 500M (5,000,000,000,000,000) for the time being
-        immutable sum = sutxo.map!(utxo => utxo.output.value)
-            .fold!((a, b) {
-                    Amount result = a;
-                    if (!a.add(b))
-                        throw new Exception("Internal error while summing UTXOs");
-                    return result;
-                })(Amount(0));
+        immutable sum = sutxo.map!(utxo => utxo.output.value).sum();
         auto mean = Amount(sum); mean.div(size);
 
         logInfo("\tMedian: %s, Avg: %s", median, mean);


### PR DESCRIPTION
It showed 0 because the calculation was wrong.
Now, the average amount is calculated properly.

```
[main(k/Y/) INF]    UTXO set: 16 entries
[main(k/Y/) INF]    Median: 304999999906200, Avg: 304999999906200
[main(k/Y/) INF]    L: 304999999906200, H: 304999999906200
```

Fixes #129 