### PR TITLE
Prevent need to restart Faucet

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -341,7 +341,14 @@ public class Faucet : FaucetAPI
             this.setup(config.tx_generator.split_count);
 
         if (this.state.update(randomClient(), Height(this.state.known + 1)))
+        {
+            // If we have no more utxo to use then let's clear sent_utxos as they may not have been externalized
+            if (this.state.owned_utxos.byKeyValue()
+                .filter!(kv => kv.key !in this.state.sent_utxos)
+                    .filter!(kv => kv.value.output.value >= minInputValuePerOutput).empty)
+                this.state.sent_utxos.clear();
             logTrace("State has been updated: %s", this.state.known);
+        }
 
         logInfo("About to send transactions...");
 

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -252,7 +252,8 @@ public class Faucet : FaucetAPI
                 this.state.sent_utxos.put(kv.key);
                 return TxBuilder(kv.value.output, kv.key);
             })
-            .map!(txb => txb.unlockSigner(&this.keyUnlocker).split(
+            .map!(txb => txb.unlockSigner(&this.keyUnlocker)
+                .split(
                     secret_keys.byKey() // AA keys are addresses
                     .cycle()    // cycle the range of keys as needed
                     .drop(uniform(0, count, rndGen))    // start at some random position


### PR DESCRIPTION
Recently in PROD env it has been required that the Faucet is restarted
as it can get into a state where it filters out all sent utxos and none
remain. The restart clears the sent_utxo and it then resumes ok. This
fix will clear the sent_utxo when no more utxo are available. It might
cause some double spend but at least it will continue to send txs.