### PR TITLE
Issue153 fix merge or split logic

### DIFF
--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -373,7 +373,7 @@ public class Faucet : FaucetAPI
             auto utxo_rng = this.state.owned_utxos.byKeyValue()
                 .filter!(kv => kv.key !in this.state.sent_utxos)
                 .filter!(kv => kv.value.output.value >= minInputValuePerOutput)
-                .take(uniform(10, 100, rndGen));
+                .take(uniform(2, config.tx_generator.merge_threshold, rndGen));
             if (utxo_rng.empty)
                 logInfo("Waiting for unspent utxo");
             else

--- a/source/faucet/main.d
+++ b/source/faucet/main.d
@@ -367,7 +367,8 @@ public class Faucet : FaucetAPI
         logInfo("\tMedian: %s, Avg: %s", median, mean);
         logInfo("\tL: %s, H: %s", sutxo[0].output.value, sutxo[$-1].output.value);
 
-        if (this.state.utxos.storage.length > config.tx_generator.merge_threshold)
+        logInfo("\tutxo owned by Faucet: %d entries", this.state.owned_utxos.length);
+        if (this.state.owned_utxos.length > config.tx_generator.merge_threshold)
         {
             auto utxo_rng = this.state.owned_utxos.byKeyValue()
                 .filter!(kv => kv.key !in this.state.sent_utxos)


### PR DESCRIPTION
Split `owned utxo` if `owned utxo` are less than threshold otherwise merge `owned utxo`s. 
By `owned utxo` we mean those that the  faucet has the private key for so can sign.