### PR TITLE
Remove fetchRecurseSubmodules from configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "agora"]
 	path = submodules/agora
 	url = https://github.com/bosagora/agora.git
-	fetchRecurseSubmodules = true


### PR DESCRIPTION
This doesn't work for everyone, and is not required,
since the actions have a mean to specify recursive fetch.
It's mostly problematic because depth can't be specified,
so it triggers errors on Makd, a submodule of Ocean,
but not one of Agora.